### PR TITLE
音乐监听调整

### DIFF
--- a/layout/_plugins/aplayer/script.ejs
+++ b/layout/_plugins/aplayer/script.ejs
@@ -1,5 +1,5 @@
 <script>
-  volantis.APlayerController = {};
+  volantis.APlayerController = {}; // 音乐播放控制 - All
   volantis.APlayerController.id = '<%= theme.plugins.aplayer.id %>';  // 设定全局音乐播放ID
   volantis.APlayerController.volume = '<%= theme.plugins.aplayer.volume %>';
   volantis.css("https://cdn.jsdelivr.net/npm/aplayer@1.10/dist/APlayer.min.css");
@@ -16,7 +16,13 @@
 
   function SetAPlayerPlugin(){
     let Metings = document.querySelectorAll('meting-js');
-    if (Metings.length === 0) return;
+    if (Metings.length === 0) {
+      volantis.APlayerController.status = undefined;
+      <% if (theme.rightmenu.enable && theme.rightmenu.layout.includes('music')) { %>
+      if(MainAPlayer) MainAPlayer.Aplayer = {};
+      <% } %>
+      return
+    };
     if (Metings[0].aplayer && Metings[0].aplayer.on) {
       // improve the accessibility https://web.dev/button-name/
       document.querySelectorAll(".aplayer-icon-menu").forEach(e=>{
@@ -27,34 +33,40 @@
         try {
           setTimeout(() => {
             Metings.forEach((item, index) => {
-              const aplayer = item.aplayer;
+              const aplayerItem = item.aplayer; if(!aplayerItem) return;
               const rightMenuAplayer = item.meta.id === volantis.APlayerController.id && volantis.APlayerController.music;
               if(rightMenuAplayer) MainAPlayer.checkAPlayer();
-              if(!aplayer) return;
-              if(aplayer.events.events.play.every(item => {return item.name !== 'messagePlay'})) {
-                aplayer.on('play', function messagePlay() {
-                  let index = aplayer.list.index;
-                  let title = aplayer.list.audios[index].title;
-                  let artist = aplayer.list.audios[index].artist;
-                  volantis.message('音乐通知', '正在播放：' + title + ' - ' + artist, {
-                      icon: '<%- theme.plugins.message.aplayer.play %>'
-                  });
-                  if(rightMenuAplayer) volantis.APlayerController.status = 'play';
+              if(aplayerItem.events.events.play.every(item => {return item.name !== 'messagePlay'})) {
+                aplayerItem.on('play', function messagePlay() {
+                  let index = aplayerItem.list.index;
+                  let title = aplayerItem.list.audios[index].title;
+                  let artist = aplayerItem.list.audios[index].artist;
+                  setTimeout(() => {
+                    volantis.message('音乐通知', title + ' - ' + artist, {
+                      icon: '<%- theme.plugins.message.aplayer.play %>',
+                      transitionIn: 'flipInX',
+                      transitionOut: 'flipOutX'
+                    });
+                  }, 100)
+                  if(rightMenuAplayer && volantis.APlayerController) volantis.APlayerController.status = 'play';
                 });
               }
-              if(item.aplayer.events.events.pause.every(item => {return item.name !== 'messagePause'})) {
-                aplayer.on('pause', function messagePause() {
-                  let index = aplayer.list.index;
-                  let title = aplayer.list.audios[index].title;
-                  let artist = aplayer.list.audios[index].artist;
+              if(aplayerItem.events.events.pause.every(item => {return item.name !== 'messagePause'})) {
+                aplayerItem.on('pause', function messagePause() {
+                  let index = aplayerItem.list.index;
+                  let title = aplayerItem.list.audios[index].title;
+                  let artist = aplayerItem.list.audios[index].artist;
                   setTimeout(() => {
                     // 歌曲播放结束也会触发 pause 事件，为了避免错误提示，等待一会儿
-                    if(aplayer.paused)
-                      volantis.message('音乐通知', '暂停播放：' + title + ' - ' + artist, {
-                          icon: '<%- theme.plugins.message.aplayer.pause %>'
+                    if(aplayerItem.paused) {
+                      volantis.message('音乐通知', title + ' - ' + artist, {
+                        icon: '<%- theme.plugins.message.aplayer.pause %>',
+                        transitionIn: 'flipInX',
+                        transitionOut: 'flipOutX'
                       });
+                    }
                   }, 100)
-                  if(rightMenuAplayer) volantis.APlayerController.status = 'pause';
+                  if(rightMenuAplayer && volantis.APlayerController) volantis.APlayerController.status = 'pause';
                 });
               }
             });

--- a/layout/_plugins/message/script.ejs
+++ b/layout/_plugins/message/script.ejs
@@ -1,6 +1,6 @@
 <script>
   volantis.message = (title, message, option = {}, done = null) => {
-    if (typeof iziToast == "undefined") {
+    if (typeof iziToast === "undefined") {
       volantis.css('<%- theme.cdn.map.css.message %>')
       volantis.js('<%- theme.cdn.map.js.message %>', () => {
         tozashMessage(title, message, option, done);
@@ -19,13 +19,14 @@
         messageColor,
         titleColor,
         backgroundColor,
-        zindex
+        zindex,
+        displayMode
       } = option;
       iziToast.show({
         layout: '2',
         icon: 'Fontawesome',
         closeOnEscape: 'true',
-        displayMode: 'replace',
+        displayMode: displayMode || 'replace',
         transitionIn: transitionIn || '<%- theme.plugins.message.transitionIn %>',
         transitionOut: transitionOut || '<%- theme.plugins.message.transitionOut %>',
         messageColor: messageColor || '<%- theme.plugins.message.messageColor %>',
@@ -45,7 +46,7 @@
   };
 
   volantis.question = (title, message, option = {}, success = null, cancel = null, done = null) => {
-    if (typeof iziToast == "undefined") {
+    if (typeof iziToast === "undefined") {
       volantis.css('<%- theme.cdn.map.css.message %>')
       volantis.js('<%- theme.cdn.map.js.message %>', () => {
         tozashQuestion(title, message, option, success, cancel, done);
@@ -95,6 +96,28 @@
           if(done) done(instance, toast, closedBy);
         }
       });
+    }
+  }
+
+  volantis.hideMessage = (done = null) => {
+    const toast = document.querySelector('.iziToast');
+    if (!toast) {
+      if(done) done()
+      return;
+    }
+    
+    if (typeof iziToast === "undefined") {
+      volantis.css('<%- theme.cdn.map.css.message %>')
+      volantis.js('<%- theme.cdn.map.js.message %>', () => {
+        hideMessage(done);
+      });
+    } else {
+      hideMessage(done);
+    }
+
+    function hideMessage(done) {
+      iziToast.hide({}, toast);
+      if(done) done();
     }
   }
 

--- a/source/js/aplayer.js
+++ b/source/js/aplayer.js
@@ -1,17 +1,12 @@
 /**
  * 右键音乐
  * */
-const MainAPlayer = (() => {
-  const APlayer = {};
+ const MainAPlayer = (() => {
+  const APlayer = {}; // 右键音乐所控制的播放器
   const fn = {};
 
-  fn.init = () => {
-    APlayer.id = volantis.APlayerController.id;
-    APlayer.volume = volantis.APlayerController.volume;
-  }
-
   fn.checkAPlayer = () => {
-    if (APlayer.player === undefined) {
+    if (volantis.APlayerController.status === undefined || APlayer.player === undefined) {
       fn.setAPlayerObject();
     } else if (APlayer.observer === undefined) {
       fn.setAPlayerObserver();
@@ -20,17 +15,16 @@ const MainAPlayer = (() => {
 
   // 设置全局播放器所对应的 aplyer 对象
   fn.setAPlayerObject = () => {
-    let meting = document.querySelectorAll('.footer meting-js') || [];
+    let meting = document.querySelectorAll('.footer meting-js');
     if (meting.length == 0) {
-      meting = document.querySelectorAll('meting-js') || [];
+      meting = document.querySelectorAll('meting-js');
     }
+    APlayer.player = undefined;
     meting.forEach((item, index) => {
-      if (item.meta.id == APlayer.id) {
-        if (meting[index].aplayer != undefined) {
-          APlayer.player = meting[index].aplayer;
-          fn.setAPlayerObserver();
-          fn.updateTitle();
-        }
+      if (item.meta.id == volantis.APlayerController.id && item.aplayer && APlayer.player === undefined) {
+        APlayer.player = item.aplayer;
+        fn.setAPlayerObserver();
+        fn.updateTitle();
       }
     });
   }
@@ -40,15 +34,19 @@ const MainAPlayer = (() => {
     try {
       APlayer.player.on('play', function (e) {
         fn.updateAPlayerControllerStatus(e);
+        APlayer.status = 'play';
       });
       APlayer.player.on('pause', function (e) {
         fn.updateAPlayerControllerStatus(e);
+        APlayer.status = 'pause';
       });
       APlayer.player.on('volumechange', function (e) {
         fn.onUpdateAPlayerVolume(e);
+        APlayer.status = 'volumechange';
       });
       APlayer.player.on('loadstart', function (e) {
         fn.updateTitle(e);
+        APlayer.status = 'loadstart';
       });
 
       // 监听音量手势
@@ -169,14 +167,11 @@ const MainAPlayer = (() => {
       const obj = APlayer.player.list.audios[index];
       document.getElementsByClassName('nav music-title')[0].innerHTML = obj.title;
     } catch (error) {
-      console.log(error);
+      //console.log(error);
     }
   }
 
   return {
-    init: () => {
-      fn.init();
-    },
     checkAPlayer: () => {
       fn.checkAPlayer();
     },
@@ -188,13 +183,13 @@ const MainAPlayer = (() => {
     },
     aplayerForward: () => {
       fn.aplayerForward();
-    }
+    },
+    APlayer: APlayer
   }
 })()
 
 Object.freeze(MainAPlayer);
 
 volantis.requestAnimationFrame(() => {
-  MainAPlayer.init();
   MainAPlayer.checkAPlayer();
 });

--- a/source/js/rightMenu.js
+++ b/source/js/rightMenu.js
@@ -245,7 +245,7 @@ const RightMenu = (() => {
       fn.visible(_readingModel, false);
     }
 
-    if (volantis.APlayerController.status === 'play') {
+    if (volantis.APlayerController && MainAPlayer && MainAPlayer.APlayer.status === 'play') {
       optionFlag = true;
       fn.visible(_menuMusic);
     } else {


### PR DESCRIPTION
1.修改音乐通知的展示，播放/暂停以图标区别
2.解决全局音乐与文章页音乐 ID 相同带来的错误
3.当存在多个相同的全局 ID 所对应的音乐播放器时，右键音乐控制以页脚/首个为先
4.全局音乐播放器事件对外抛出

## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->


## Others

- Issue resolved: 

- Screenshots with this changes: 

- Link to demo site with this changes: 

